### PR TITLE
fix: CI indent wrong

### DIFF
--- a/.github/workflows/new_version_pr.yml
+++ b/.github/workflows/new_version_pr.yml
@@ -78,10 +78,10 @@ jobs:
           git add VERSION
           git commit -m "Release version ${{ env.new_version }}"
 
-          - name: Set up Ruby
-          uses: ruby/setup-ruby@v1
-          with:
-            ruby-version: '3.0' # or any preferred version
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.0"
 
       - name: Install GitHub Changelog Generator
         run: gem install github_changelog_generator


### PR DESCRIPTION
## Summary by Sourcery

Correct the indentation in the GitHub Actions workflow file to ensure proper execution of the Ruby setup step.

CI:
- Fix indentation issue in the GitHub Actions workflow file for setting up Ruby.