### PR TITLE
Add status badges to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,9 @@
 # Playnite Web MQTT Integration
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://hacs.xyz/)
+[![HACS](https://github.com/cvele/playnite_web_mqtt/actions/workflows/validate_hacs.yml/badge.svg)](https://github.com/cvele/playnite_web_mqtt/actions/workflows/validate_hacs.yml)
+[![Hassfest](https://github.com/cvele/playnite_web_mqtt/actions/workflows/validate_hassfest.yml/badge.svg)](https://github.com/cvele/playnite_web_mqtt/actions/workflows/validate_hassfest.yml)
+[![CI](https://github.com/cvele/playnite_web_mqtt/actions/workflows/ci-checks.yml/badge.svg)](https://github.com/cvele/playnite_web_mqtt/actions/workflows/ci-checks.yml)
 
 > ⚠️ **Warning**: This project is still in development. Use at your own risk!
 


### PR DESCRIPTION
## Summary by Sourcery

Add status badges to the README to display the status of HACS validation, Hassfest validation, and CI checks.

Documentation:
- Add status badges for HACS validation, Hassfest validation, and CI checks to the README file.