### PR TITLE
Add translations and update MQTT config flow for Playnite Web MQTT

### DIFF
--- a/custom_components/playnite_web_mqtt/config_flow.py
+++ b/custom_components/playnite_web_mqtt/config_flow.py
@@ -38,6 +38,7 @@ class PlayniteMQTTConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
         return PlayniteMQTTOptionsFlow(config_entry)
 
 
@@ -57,19 +58,19 @@ class PlayniteMQTTOptionsFlow(config_entries.OptionsFlow):
             {
                 vol.Required(
                     "mqtt_broker",
-                    default=self.config_entry.options.get("mqtt_broker", ""),
+                    default=self.config_entry.data.get("mqtt_broker", ""),
                 ): str,
                 vol.Optional(
                     "mqtt_username",
-                    default=self.config_entry.options.get("mqtt_username", ""),
+                    default=self.config_entry.data.get("mqtt_username", ""),
                 ): str,
                 vol.Optional(
                     "mqtt_password",
-                    default=self.config_entry.options.get("mqtt_password", ""),
+                    default=self.config_entry.data.get("mqtt_password", ""),
                 ): str,
                 vol.Optional(
                     "topic_base",
-                    default=self.config_entry.options.get(
+                    default=self.config_entry.data.get(
                         "topic_base", "playnite"
                     ),
                 ): str,

--- a/custom_components/playnite_web_mqtt/translations/en.json
+++ b/custom_components/playnite_web_mqtt/translations/en.json
@@ -1,0 +1,38 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "mqtt_broker": "MQTT Broker",
+          "mqtt_port": "MQTT Port",
+          "mqtt_username": "MQTT Username",
+          "mqtt_password": "MQTT Password",
+          "topic_base": "Base MQTT Topic"
+        },
+        "title": "Configure Playnite Web MQTT",
+        "description": "Please enter your MQTT broker details."
+      }
+    },
+    "error": {
+      "invalid_broker": "Invalid MQTT broker address"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "mqtt_broker": "MQTT Broker",
+          "mqtt_username": "MQTT Username",
+          "mqtt_password": "MQTT Password",
+          "topic_base": "Base MQTT Topic",
+          "max_image_size": "Max Image Size (KB)",
+          "min_quality": "Minimum Image Quality",
+          "initial_quality": "Initial Image Quality",
+          "max_concurrent_compressions": "Max Concurrent Compressions"
+        },
+        "title": "Configure Playnite MQTT Options",
+        "description": "Configure additional options for Playnite Web MQTT."
+      }
+    }
+  }
+}

--- a/custom_components/playnite_web_mqtt/translations/sr-Latn.json
+++ b/custom_components/playnite_web_mqtt/translations/sr-Latn.json
@@ -1,0 +1,38 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "mqtt_broker": "MQTT Broker",
+          "mqtt_port": "MQTT Port",
+          "mqtt_username": "MQTT Korisničko ime",
+          "mqtt_password": "MQTT Lozinka",
+          "topic_base": "Osnovna MQTT Tema"
+        },
+        "title": "Konfigurišite Playnite Web MQTT",
+        "description": "Molimo unesite detalje vašeg MQTT brokera."
+      }
+    },
+    "error": {
+      "invalid_broker": "Nevažeća adresa MQTT brokera"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "mqtt_broker": "MQTT Broker",
+          "mqtt_username": "MQTT Korisničko ime",
+          "mqtt_password": "MQTT Lozinka",
+          "topic_base": "Osnovna MQTT Tema",
+          "max_image_size": "Maksimalna veličina slike (KB)",
+          "min_quality": "Minimalni kvalitet slike",
+          "initial_quality": "Početni kvalitet slike",
+          "max_concurrent_compressions": "Maksimalan broj istovremenih kompresija"
+        },
+        "title": "Konfigurišite Playnite MQTT Opcije",
+        "description": "Konfigurišite dodatne opcije za Playnite Web MQTT."
+      }
+    }
+  }
+}

--- a/custom_components/playnite_web_mqtt/translations/sr.json
+++ b/custom_components/playnite_web_mqtt/translations/sr.json
@@ -1,0 +1,38 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "mqtt_broker": "MQTT Брокер",
+          "mqtt_port": "MQTT Порт",
+          "mqtt_username": "MQTT Корисничко име",
+          "mqtt_password": "MQTT Лозинка",
+          "topic_base": "Основна MQTT Тема"
+        },
+        "title": "Конфигуришите Playnite Web MQTT",
+        "description": "Молимо унесите детаље вашег MQTT брокера."
+      }
+    },
+    "error": {
+      "invalid_broker": "Неважећа адреса MQTT брокера"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "mqtt_broker": "MQTT Брокер",
+          "mqtt_username": "MQTT Корисничко име",
+          "mqtt_password": "MQTT Лозинка",
+          "topic_base": "Основна MQTT Тема",
+          "max_image_size": "Максимална величина слике (KB)",
+          "min_quality": "Минимални квалитет слике",
+          "initial_quality": "Почетни квалитет слике",
+          "max_concurrent_compressions": "Максималан број истовремених компресија"
+        },
+        "title": "Конфигуришите Playnite MQTT Опције",
+        "description": "Конфигуришите додатне опције за Playnite Web MQTT."
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary by Sourcery

Add translations for Playnite Web MQTT configuration in English and Serbian, and update the MQTT config flow to use config entry data for default values.

New Features:
- Add English, Serbian Latin, and Serbian translations for the Playnite Web MQTT configuration and options.

Enhancements:
- Update the MQTT configuration flow to use data from the config entry instead of options for default values.